### PR TITLE
Add GssapiSignalPersistentAuth directive to send the Persistent-Auth hea...

### DIFF
--- a/README
+++ b/README
@@ -89,12 +89,17 @@ authentication (like NTLMSSP) it is necessary to bind to the authentication to
 the connection in order to keep the state between round-trips. With this option
 enable incomplete context are store in the connection and retrieved on the next
 request for continuation.
-When using this option you may also ant to set the Persistent-Auth header for
-those clients that make use of it.
 
 Example:
     GssapiConnectionBound On
-    Header set Persistent-Auth "true"
+
+
+### GssapiSignalPersistentAuth
+For clients that make use of Persistent-Auth header, send the header according
+to GssapiConnectionBound setting.
+
+Example:
+    GssapiSignalPersistentAuth On
 
 
 ### GssapiUseSessions

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -565,6 +565,10 @@ static int mag_auth(request_rec *req)
         mc->auth_type = auth_type;
     }
 
+    if (cfg->send_persist)
+        apr_table_set(req->headers_out, "Persistent-Auth",
+            cfg->gss_conn_ctx ? "true" : "false");
+
     ret = OK;
 
 done:
@@ -640,6 +644,13 @@ static const char *mag_conn_ctx(cmd_parms *parms, void *mconfig, int on)
 {
     struct mag_config *cfg = (struct mag_config *)mconfig;
     cfg->gss_conn_ctx = on ? true : false;
+    return NULL;
+}
+
+static const char *mag_send_persist(cmd_parms *parms, void *mconfig, int on)
+{
+    struct mag_config *cfg = (struct mag_config *)mconfig;
+    cfg->send_persist = on ? true : false;
     return NULL;
 }
 
@@ -796,6 +807,8 @@ static const command_rec mag_commands[] = {
                   "Translate principals to local names"),
     AP_INIT_FLAG("GssapiConnectionBound", mag_conn_ctx, NULL, OR_AUTHCFG,
                   "Authentication is bound to the TCP connection"),
+    AP_INIT_FLAG("GssapiSignalPersistentAuth", mag_send_persist, NULL, OR_AUTHCFG,
+                  "Send Persitent-Auth header according to connection bound"),
     AP_INIT_FLAG("GssapiUseSessions", mag_use_sess, NULL, OR_AUTHCFG,
                   "Authentication uses mod_sessions to hold status"),
     AP_INIT_RAW_ARGS("GssapiSessionKey", mag_sess_key, NULL, OR_AUTHCFG,

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -39,6 +39,7 @@ struct mag_config {
     bool ssl_only;
     bool map_to_local;
     bool gss_conn_ctx;
+    bool send_persist;
     bool use_sessions;
     bool use_s4u2proxy;
     char *deleg_ccache_dir;


### PR DESCRIPTION
...der only when necessary

According to MS doc: The Persistent-Auth header is only valid when sent with the final response from the server after authentication has completed.

https://msdn.microsoft.com/en-us/library/ee393311.aspx?f=255&MSPPError=-2147217396

With this fix mod_auth_gssapi only sends the header when necessary.

Signaling "false" isn't currently practical as that's what the client expect by default with non-NTLM auth, while in case of NTLM the authentication will never succeed if GssapiConnectionBound is off (in IIS you can set authPersistSingleRequest to true then NTLM bound to the connection only to succeed the request, send Persistent-Auth with false and require authentication for subsequent requests on the same connection).