### PR TITLE
Disable connection-bound for basic-auth

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -579,6 +579,8 @@ static int mag_auth(request_rec *req)
         goto done;
     }
     if (auth_type == AUTH_TYPE_BASIC) {
+        apr_pool_cleanup_run(mc->parent, mc, mag_conn_destroy);
+        mc = NULL;
         while (maj == GSS_S_CONTINUE_NEEDED) {
             gss_release_buffer(&min, &input);
             /* output and input are inverted here, this is intentional */


### PR DESCRIPTION
Clients don't expect this and therefore might inappropriately reuse the
connection for another user identity (with or without creds).

This is currently more of an issue due to issue 22, example:
curl -v http://myhost/ -u usera:passa --next http://myhost/ -u userb:passb

I have more ideas on the subject but I think for now this should do.

Regards,
Isaac B.