### PR TITLE
Always require authentication with basic auth

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -587,7 +587,9 @@ static int mag_auth(request_rec *req)
     auth_header = apr_table_get(req->headers_in, "Authorization");
 
     if (mc) {
-        if (mc->established && !auth_header) {
+        if (mc->established &&
+            (auth_header == NULL) &&
+            (mc->auth_type != AUTH_TYPE_BASIC)) {
             ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, req,
                           "Already established context found!");
             mag_set_req_data(req, cfg, mc);


### PR DESCRIPTION
When connection bound authentication is used, we must deny access if
basci auth is used and a request does not have the basic auth header.
Basic auth authenticate each and every request, so if it is missing
this means such request is no more authenticated and we should not
allow access based on our cached metadata in this case.

Signed-off-by: Simo Sorce <simo@redhat.com>