### PR TITLE
Allow only the correct mechs

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -24,6 +24,10 @@
 
 #include "mod_auth_gssapi.h"
 
+const gss_OID_desc gss_mech_spnego = {
+    6, "\x2b\x06\x01\x05\x05\x02"
+};
+
 const gss_OID_desc gss_mech_ntlmssp = {
     GSS_NTLMSSP_OID_LENGTH, GSS_NTLMSSP_OID_STRING
 };
@@ -530,6 +534,8 @@ static int mag_auth(request_rec *req)
         (void)gss_release_cred(&min, &server_cred);
     }
 
+    desired_mechs = cfg->allowed_mechs;
+
     /* implicit auth for subrequests if main auth already happened */
     if (!ap_is_initial_req(req) && req->main != NULL) {
         type = ap_auth_type(req->main);
@@ -1009,6 +1015,9 @@ static const char *mag_allow_mech(cmd_parms *parms, void *mconfig,
                                          sizeof(gss_OID_set_desc));
         size = sizeof(gss_OID) * MAX_ALLOWED_MECHS;
         cfg->allowed_mechs->elements = apr_palloc(parms->pool, size);
+
+        cfg->allowed_mechs->elements[0] = gss_mech_spnego;
+        cfg->allowed_mechs->count++;
     }
 
     if (strcmp(w, "krb5") == 0) {

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -340,7 +340,6 @@ static bool mag_auth_basic(request_rec *req,
                            struct mag_config *cfg,
                            gss_buffer_desc ba_user,
                            gss_buffer_desc ba_pwd,
-                           gss_cred_id_t acquired_cred,
                            gss_cred_usage_t cred_usage,
                            gss_name_t *client,
                            gss_OID *mech_type,
@@ -363,6 +362,7 @@ static bool mag_auth_basic(request_rec *req,
     gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
     gss_OID_set allowed_mechs = GSS_C_NO_OID_SET;
     gss_OID_set_desc all_mechs_desc;
+    gss_OID_set actual_mechs = GSS_C_NO_OID_SET;
     uint32_t init_flags = 0;
     uint32_t maj, min;
     bool ret = false;
@@ -405,33 +405,12 @@ static bool mag_auth_basic(request_rec *req,
                                          GSS_C_INDEFINITE,
                                          allowed_mechs,
                                          GSS_C_INITIATE,
-                                         &user_cred, NULL, NULL);
+                                         &user_cred, &actual_mechs, NULL);
     if (GSS_ERROR(maj)) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
                       "In Basic Auth, %s",
                       mag_error(req, "gss_acquire_cred_with_password() "
                                 "failed", maj, min));
-        goto done;
-    }
-
-    if (cred_usage == GSS_C_BOTH) {
-        /* If GSS_C_BOTH is used then inquire_cred will return the client
-         * name instead of the SPN of the server credentials. Therefore we
-         * need to acquire a different set of credential setting
-         * GSS_C_ACCEPT explicitly */
-        if (!mag_acquire_creds(req, cfg, allowed_mechs,
-                               GSS_C_ACCEPT, &server_cred, NULL)) {
-            goto done;
-        }
-    } else {
-        server_cred = acquired_cred;
-    }
-    maj = gss_inquire_cred(&min, server_cred, &server,
-                           NULL, NULL, NULL);
-    if (GSS_ERROR(maj)) {
-        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
-                      "%s", mag_error(req, "gss_inquired_cred_() "
-                                      "failed", maj, min));
         goto done;
     }
 
@@ -442,45 +421,89 @@ static bool mag_auth_basic(request_rec *req,
     }
 #endif
 
-    do {
-        /* output and input are inverted here, this is intentional */
-        maj = gss_init_sec_context(&min, user_cred, &user_ctx, server,
-                                   GSS_C_NO_OID, init_flags, 300,
-                                   GSS_C_NO_CHANNEL_BINDINGS, &output,
-                                   NULL, &input, NULL, NULL);
-        if (GSS_ERROR(maj)) {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
-                          "%s", mag_error(req, "gss_init_sec_context() "
-                                          "failed", maj, min));
-            goto done;
-        }
-        gss_release_buffer(&min, &output);
-        maj = gss_accept_sec_context(&min, &server_ctx, acquired_cred,
-                                     &input, GSS_C_NO_CHANNEL_BINDINGS,
-                                     client, mech_type, &output, NULL,
-                                     vtime, delegated_cred);
-        if (GSS_ERROR(maj)) {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
-                          "%s", mag_error(req, "gss_accept_sec_context()"
-                                          " failed", maj, min));
-            goto done;
-        }
-        gss_release_buffer(&min, &input);
-    } while (maj == GSS_S_CONTINUE_NEEDED);
+    for (int i = 0; i < actual_mechs->count; i++) {
 
-    ret = true;
+        /* skip spnego if present (it is usually present when
+         * cfg->allowed_mechs is not set) */
+        if (gss_oid_equal(&actual_mechs->elements[i],
+                          &gss_mech_spnego)) {
+            continue;
+        }
+
+        /* free these if looping */
+        gss_release_buffer(&min, &output);
+        gss_release_buffer(&min, &input);
+        gss_release_name(&min, &server);
+        gss_release_cred(&min, &server_cred);
+
+        all_mechs_desc.count = 1;
+        all_mechs_desc.elements = &actual_mechs->elements[i];
+
+        /* must acquire with GSS_C_ACCEPT to get the server name */
+        if (!mag_acquire_creds(req, cfg, allowed_mechs,
+                               GSS_C_ACCEPT, &server_cred, NULL)) {
+            continue;
+        }
+        maj = gss_inquire_cred(&min, server_cred, &server,
+                               NULL, NULL, NULL);
+        if (GSS_ERROR(maj)) {
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
+                          "%s", mag_error(req, "gss_inquired_cred_() "
+                                          "failed", maj, min));
+            continue;
+        }
+
+        if (cred_usage == GSS_C_BOTH) {
+            /* reacquire server creds in order to allow delegation */
+            gss_release_cred(&min, &server_cred);
+            if (!mag_acquire_creds(req, cfg, allowed_mechs,
+                                   GSS_C_BOTH, &server_cred, NULL)) {
+                continue;
+            }
+        }
+
+        do {
+            /* output and input are inverted here, this is intentional */
+            maj = gss_init_sec_context(&min, user_cred, &user_ctx, server,
+                                       &actual_mechs->elements[i], init_flags,
+                                       300, GSS_C_NO_CHANNEL_BINDINGS, &output,
+                                       NULL, &input, NULL, NULL);
+            if (GSS_ERROR(maj)) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
+                              "%s", mag_error(req, "gss_init_sec_context() "
+                                              "failed", maj, min));
+                break;
+            }
+            gss_release_buffer(&min, &output);
+            maj = gss_accept_sec_context(&min, &server_ctx, server_cred,
+                                         &input, GSS_C_NO_CHANNEL_BINDINGS,
+                                         client, mech_type, &output, NULL,
+                                         vtime, delegated_cred);
+            if (GSS_ERROR(maj)) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
+                              "%s", mag_error(req, "gss_accept_sec_context()"
+                                              " failed", maj, min));
+                break;
+            }
+            gss_release_buffer(&min, &input);
+        } while (maj == GSS_S_CONTINUE_NEEDED);
+
+        if (maj == GSS_S_COMPLETE) {
+            ret = true;
+            break;
+        }
+    }
 
 done:
     gss_release_buffer(&min, &output);
     gss_release_buffer(&min, &input);
     gss_release_name(&min, &server);
-    if (server_cred != acquired_cred) {
-        gss_release_cred(&min, &server_cred);
-    }
+    gss_release_cred(&min, &server_cred);
     gss_delete_sec_context(&min, &server_ctx, GSS_C_NO_BUFFER);
     gss_release_name(&min, &user);
     gss_release_cred(&min, &user_cred);
     gss_delete_sec_context(&min, &user_ctx, GSS_C_NO_BUFFER);
+    gss_release_oid_set(&min, &actual_mechs);
 #ifdef HAVE_GSS_KRB5_CCACHE_NAME
     if (user_ccache != NULL) {
         maj = gss_krb5_ccache_name(&min, orig_ccache, NULL);
@@ -700,18 +723,17 @@ static int mag_auth(request_rec *req)
         cred_usage = GSS_C_BOTH;
     }
 #endif
-    if (!mag_acquire_creds(req, cfg, desired_mechs,
-                           cred_usage, &acquired_cred, NULL)) {
-        goto done;
-    }
-
     if (auth_type == AUTH_TYPE_BASIC) {
         if (mag_auth_basic(req, cfg, ba_user, ba_pwd,
-                           acquired_cred, cred_usage,
-                           &client, &mech_type,
+                           cred_usage, &client, &mech_type,
                            &delegated_cred, &vtime)) {
             goto complete;
         }
+        goto done;
+    }
+
+    if (!mag_acquire_creds(req, cfg, desired_mechs,
+                           cred_usage, &acquired_cred, NULL)) {
         goto done;
     }
 


### PR DESCRIPTION
Properly restrict the mechanism we want to allow even if the client misuses the Negotiate key word to perform raw NTLM/Kerb/Whatever authentication instead of using SPNEGO.