### PR TITLE
Add GssapiBasicAuthMechs options

### DIFF
--- a/README
+++ b/README
@@ -216,3 +216,16 @@ are allowed.  The recognized mechanism names are: krb5, iakerb, ntlmssp
 Example:
     GssapiAllowedMech krb5
     GssapiAllowedMech ntlmssp
+
+
+### GssapiBasicAuthMech
+
+List of mechanisms against which Basic Auth is attempted. This is useful to
+restrict the mechanisms that can be used to attaempt password auth.
+By default no mechanism is set, this means all locally available mechanisms
+are allowed, unless GssapiAllowedMech is set, in which case those are used.
+GssapiBasicAuthMech always takes precendence over GssapiAllowedMech.
+The recognized mechanism names are: krb5, iakerb, ntlmssp
+
+Example:
+    GssapiBasicAuthMech krb5

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -402,12 +402,12 @@ static bool mag_auth_basic(request_rec *req,
     gss_name_t server = GSS_C_NO_NAME;
     gss_cred_id_t server_cred = GSS_C_NO_CREDENTIAL;
     gss_ctx_id_t server_ctx = GSS_C_NO_CONTEXT;
+    gss_cred_id_t acquired_cred = GSS_C_NO_CREDENTIAL;
     gss_buffer_desc input = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
     gss_OID_set indicated_mechs = GSS_C_NO_OID_SET;
     gss_OID_set allowed_mechs;
     gss_OID_set filtered_mechs;
-    gss_OID_set_desc all_mechs_desc;
     gss_OID_set actual_mechs = GSS_C_NO_OID_SET;
     uint32_t init_flags = 0;
     uint32_t maj, min;
@@ -524,6 +524,22 @@ static bool mag_auth_basic(request_rec *req,
         goto done;
     }
 
+    /* must acquire creds based on the actual mechs we want to try */
+    if (!mag_acquire_creds(req, cfg, actual_mechs,
+                           GSS_C_BOTH, &acquired_cred, NULL)) {
+        goto done;
+    }
+
+    if (cred_usage == GSS_C_BOTH) {
+        /* must acquire with GSS_C_ACCEPT to get the server name */
+        if (!mag_acquire_creds(req, cfg, actual_mechs,
+                               GSS_C_ACCEPT, &server_cred, NULL)) {
+            goto done;
+        }
+    } else {
+        server_cred = acquired_cred;
+    }
+
 #ifdef HAVE_CRED_STORE
     if (cfg->deleg_ccache_dir) {
         /* delegate ourselves credentials so we store them as requested */
@@ -543,33 +559,15 @@ static bool mag_auth_basic(request_rec *req,
         gss_release_buffer(&min, &output);
         gss_release_buffer(&min, &input);
         gss_release_name(&min, &server);
-        gss_release_cred(&min, &server_cred);
 
-        all_mechs_desc.count = 1;
-        all_mechs_desc.elements = &actual_mechs->elements[i];
-        allowed_mechs = &all_mechs_desc;
-
-        /* must acquire with GSS_C_ACCEPT to get the server name */
-        if (!mag_acquire_creds(req, cfg, allowed_mechs,
-                               GSS_C_ACCEPT, &server_cred, NULL)) {
-            continue;
-        }
-        maj = gss_inquire_cred(&min, server_cred, &server,
-                               NULL, NULL, NULL);
+        maj = gss_inquire_cred_by_mech(&min, server_cred,
+                                       &actual_mechs->elements[i],
+                                       &server, NULL, NULL, NULL);
         if (GSS_ERROR(maj)) {
             ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
-                          "%s", mag_error(req, "gss_inquired_cred_() "
+                          "%s", mag_error(req, "gss_inquired_cred_by_mech() "
                                           "failed", maj, min));
             continue;
-        }
-
-        if (cred_usage == GSS_C_BOTH) {
-            /* reacquire server creds in order to allow delegation */
-            gss_release_cred(&min, &server_cred);
-            if (!mag_acquire_creds(req, cfg, allowed_mechs,
-                                   GSS_C_BOTH, &server_cred, NULL)) {
-                continue;
-            }
         }
 
         do {
@@ -585,7 +583,7 @@ static bool mag_auth_basic(request_rec *req,
                 break;
             }
             gss_release_buffer(&min, &output);
-            maj = gss_accept_sec_context(&min, &server_ctx, server_cred,
+            maj = gss_accept_sec_context(&min, &server_ctx, acquired_cred,
                                          &input, GSS_C_NO_CHANNEL_BINDINGS,
                                          client, mech_type, &output, NULL,
                                          vtime, delegated_cred);
@@ -608,8 +606,10 @@ done:
     gss_release_buffer(&min, &output);
     gss_release_buffer(&min, &input);
     gss_release_name(&min, &server);
-    gss_release_cred(&min, &server_cred);
+    if (server_cred != acquired_cred)
+        gss_release_cred(&min, &server_cred);
     gss_delete_sec_context(&min, &server_ctx, GSS_C_NO_BUFFER);
+    gss_release_cred(&min, &acquired_cred);
     gss_release_name(&min, &user);
     gss_release_cred(&min, &user_cred);
     gss_delete_sec_context(&min, &user_ctx, GSS_C_NO_BUFFER);
@@ -834,6 +834,7 @@ static int mag_auth(request_rec *req)
         cred_usage = GSS_C_BOTH;
     }
 #endif
+
     if (auth_type == AUTH_TYPE_BASIC) {
         if (mag_auth_basic(req, cfg, ba_user, ba_pwd,
                            cred_usage, &client, &mech_type,

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -55,8 +55,10 @@ struct mag_config {
     gss_key_value_set_desc *cred_store;
 #endif
     struct seal_key *mag_skey;
+
     bool use_basic_auth;
     gss_OID_set_desc *allowed_mechs;
+    gss_OID_set_desc *basic_mechs;
 };
 
 struct mag_conn {


### PR DESCRIPTION
This option allows to set a different list of mechanisms to use
with Basic Auth (Basic Auth must be explicitly enabled) than the
list of mechs that are allowed with Negotiate or Raw GSSAPI Client
authentication.

Signed-off-by: Simo Sorce <simo@redhat.com>