### PR TITLE
Add test for Proxy SPNEGO auth

### DIFF
--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -273,6 +273,16 @@ def test_spnego_auth(testdir, testenv, testlog):
         else:
             sys.stderr.write('SPNEGO: SUCCESS\n')
 
+    with (open(testlog, 'a')) as logfile:
+        spnego = subprocess.Popen(["tests/t_spnego_proxy.py"],
+                                  stdout=logfile, stderr=logfile,
+                                  env=testenv, preexec_fn=os.setsid)
+        spnego.wait()
+        if spnego.returncode != 0:
+            sys.stderr.write('SPNEGO Proxy Auth: FAILED\n')
+        else:
+            sys.stderr.write('SPNEGO Proxy Auth: SUCCESS\n')
+
 
 def test_basic_auth_krb5(testdir, testenv, testlog):
 

--- a/tests/t_spnego_proxy.py
+++ b/tests/t_spnego_proxy.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+import requests
+import gssapi
+from base64 import b64encode
+
+def getAuthToken(target):
+    name = gssapi.Name('HTTP@%s' % target,
+                       gssapi.NameType.hostbased_service)
+    ctx = gssapi.SecurityContext(name=name)
+    token = ctx.step()
+    
+    return 'Negotiate %s' % b64encode(token)
+
+
+if __name__ == '__main__':
+    s = requests.Session()
+
+    target = os.environ['NSS_WRAPPER_HOSTNAME']
+    url = 'http://%s/spnego/' % target
+
+    proxy = 'http://%s:%s' % (target, os.environ['WRAP_PROXY_PORT'])
+    proxies = { "http" : proxy, }
+
+    s.headers.update({'Proxy-Authorization': getAuthToken(target)})
+    s.headers.update({'Authorization': getAuthToken(target)})
+
+    r = s.get(url, proxies=proxies)
+    if r.status_code != 200:
+        raise ValueError('Spnego Proxy Auth Failed')

--- a/tests/t_spnego_proxy.py
+++ b/tests/t_spnego_proxy.py
@@ -7,9 +7,12 @@ import gssapi
 from base64 import b64encode
 
 def getAuthToken(target):
+    spnego_mech = gssapi.raw.OID.from_int_seq('1.3.6.1.5.5.2')
+
     name = gssapi.Name('HTTP@%s' % target,
                        gssapi.NameType.hostbased_service)
-    ctx = gssapi.SecurityContext(name=name)
+
+    ctx = gssapi.SecurityContext(name=name, mech=spnego_mech)
     token = ctx.step()
     
     return 'Negotiate %s' % b64encode(token)


### PR DESCRIPTION
The Authorization headers are initially added (generated by gssapi module).

As discussed at #48

Thanks,
Isaac B.