### PR TITLE
Updating session established to false if session has expired.

### DIFF
--- a/src/sessions.c
+++ b/src/sessions.c
@@ -157,6 +157,7 @@ void mag_check_session(struct mag_req_cfg *cfg, struct mag_conn **conn)
     expiration = gsessdata->expiration;
     if (expiration < time(NULL)) {
         /* credentials fully expired, return nothing */
+        mc->established = false;
         goto done;
     }
 


### PR DESCRIPTION
If the session is expired, then set established to false to force a 401 for re-authentication.

Noticed that Apache 2.4.x would throw a 500 error if a cookie/session had expired as the variable mc->established was always true.

By setting mc->established to false when the session was expired, the resulting code is a 401, which forces renegotiation of authentication.