### PR TITLE
Fix/apxs specify boostrap symbol name

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,8 +20,8 @@ mod_auth_gssapi_la_LDFLAGS = \
     -export-symbols-regex auth_gssapi_module
 
 install-exec-local:
-	if test ! -d ${APXS_LIBEXECDIR}; then mkdir -p ${APXS_LIBEXECDIR}; fi
-	@APXS@ -i -S LIBEXECDIR=${APXS_LIBEXECDIR} mod_auth_gssapi.la
+	test -d $(DESTDIR)$(APXS_LIBEXECDIR) || mkdir -p $(DESTDIR)$(APXS_LIBEXECDIR)
+	@APXS@ -i -S LIBEXECDIR=$(DESTDIR)$(APXS_LIBEXECDIR) mod_auth_gssapi.la
 
 clean-local:
 	rm -f mod_auth_gssapi.slo mod_auth_gssapi.la mod_auth_gssapi.lo .libs

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@ mod_auth_gssapi_la_LDFLAGS = \
 
 install-exec-local:
 	test -d $(DESTDIR)$(APXS_LIBEXECDIR) || mkdir -p $(DESTDIR)$(APXS_LIBEXECDIR)
-	@APXS@ -i -S LIBEXECDIR=$(DESTDIR)$(APXS_LIBEXECDIR) mod_auth_gssapi.la
+	@APXS@ -i -n mod_auth_gssapi -S LIBEXECDIR=$(DESTDIR)$(APXS_LIBEXECDIR) mod_auth_gssapi.la
 
 clean-local:
 	rm -f mod_auth_gssapi.slo mod_auth_gssapi.la mod_auth_gssapi.lo .libs


### PR DESCRIPTION
I saw following error, which is maybe related to out-of-source builds:
```
test -d /target/usr/lib/apache2/modules || mkdir -p /target/usr/lib/apache2/modules
/usr/bin/apxs2 -i -S LIBEXECDIR=/target/usr/lib/apache2/modules mod_auth_gssapi.la
apxs:Error: Sorry, cannot determine bootstrap symbol name.
apxs:Error: Please specify one with option `-n'.
Makefile:725: recipe for target 'install-exec-local' failed
```

This patch fixes it in the way recommended by APXS.

Depends upon / includes #78, because that one affects the same line.