### PR TITLE
GSS-Proxy configuration file for mod_auth_gssapi

### DIFF
--- a/contrib/80-httpd.conf
+++ b/contrib/80-httpd.conf
@@ -1,0 +1,6 @@
+# gssproxy configuration file for mod_auth_gssapi
+[service/HTTP]
+  mechs = krb5
+  cred_store = keytab:/etc/gssproxy/http.keytab
+  cred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U
+  euid = apache


### PR DESCRIPTION
For packaging purposes, it makes sense for mod_auth_gssapi to provide its own gssproxy configuration file.  This way, gssproxy avoids being in a situation where a user mentioned in the config file may not exist.

On a related note, this will not work on Debian because Debian calls its apache user "www-data".  (It also has a different UID than Fedora's - 33 vs. 48.)  We could make it work with autoconf magic, but I'm not sure whether that's worth the effort.