### PR TITLE
Additional python modules are needed.

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,8 @@ To run tests, you also need:
 
 * The Kerberos 5 Key-Distribution-Center (`krb5-kdc` package on Debian,
   `krb5-server` on Fedora)
-* Packages `mod_session`, `krb5-workstation` on Fedora
+* Packages `mod_session`, `krb5-workstation`, `python-requests-kerberos`,
+  and `python-gssapi` on Fedora
 * [nss_wrapper](https://cwrap.org/nss_wrapper.html), packaged in Fedora
 * [socket_wrapper](https://cwrap.org/socket_wrapper.html), packaged in Fedora
 


### PR DESCRIPTION
Failed imports were found in tracebacks in ./scratchdir/tests.log.

This should cover https://github.com/modauthgssapi/mod_auth_gssapi/issues/86 ... but I suspect some other changes to the tests code might be useful to show the tracebacks on terminal directly.