### PR TITLE
Insure the asn1 definitions are in the tarball

### DIFF
--- a/src/asn1c/Makefile.am
+++ b/src/asn1c/Makefile.am
@@ -63,6 +63,8 @@ MAGASN1dir = .
 noinst_LTLIBRARIES = libmagasn1.la
 libmagasn1_la_SOURCES = $(ASN1C_SOURCES) $(MAGASN1_SOURCES)
 
+EXTRA_DIST = session.asn1
+
 regenerate:
 	asn1c -fskeletons-copy -fnative-types session.asn1
 	rm -f converter-sample.c Makefile.am.sample


### PR DESCRIPTION
session.asn1 was not being distributed in the source tarball, making it impossible to change the generated asn1 code post distribution.