### PR TITLE
Fix setting of session cookie when unique ccaches are not used

### DIFF
--- a/src/sessions.c
+++ b/src/sessions.c
@@ -236,8 +236,13 @@ void mag_attempt_session(struct mag_req_cfg *cfg, struct mag_conn *mc)
                              (const char *)mc->basic_hash.value,
                              mc->basic_hash.length) != 0)
         goto done;
-    if (OCTET_STRING_fromString(&gsessdata.ccname, mc->ccname) != 0)
+
+    /* NULL ccname here just means default ccache */
+    if (mc->ccname &&
+        OCTET_STRING_fromString(&gsessdata.ccname, mc->ccname) != 0) {
         goto done;
+    }
+
     ret = encode_GSSSessionData(req->pool, &gsessdata,
                                 &plainbuf.value, &plainbuf.length);
     if (ret == false) {

--- a/tests/t_spnego.py
+++ b/tests/t_spnego.py
@@ -12,3 +12,7 @@ if __name__ == '__main__':
     r = sess.get(url, auth=HTTPKerberosAuth())
     if r.status_code != 200:
         raise ValueError('Spnego failed')
+
+    c = r.cookies
+    if not c.get("gssapi_session").startswith("MagBearerToken="):
+        raise ValueError('gssapi_session not set')


### PR DESCRIPTION
This is a fix for #98.  It includes a check in the tests to ensure the cookie is set as requested.