### PR TITLE
Write 'Persistent-Auth' header to err_headers_out

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1049,7 +1049,7 @@ static int mag_auth(request_rec *req)
     ret = mag_complete(req_cfg, mc, client, mech_type, vtime, delegated_cred);
 
     if (ret == OK && req_cfg->send_persist)
-        apr_table_set(req->headers_out, "Persistent-Auth",
+        apr_table_set(req->err_headers_out, "Persistent-Auth",
             cfg->gss_conn_ctx ? "true" : "false");
 
 done:


### PR DESCRIPTION
In some cases, like internal redirects, authentication is completed but our
'Persistent-Auth' header is dropped by the server because headers_out is ignored
with errors (4xx, 5xx) and internal redirects.

See: https://ci.apache.org/projects/httpd/trunk/doxygen/structrequest__rec.html#a9f49c2d5680987c0c28466ea37d41a62

This fixes #110