### PR TITLE
Make test suite runnable on Debian-likes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,5 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = src/asn1c src
 
-test: all
+check: all
 	$(srcdir)/tests/magtests.py
+
+test: check

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -38,8 +38,12 @@ LoadModule filter_module modules/mod_filter.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule include_module modules/mod_include.so
 LoadModule info_module modules/mod_info.so
-LoadModule log_config_module modules/mod_log_config.so
-LoadModule logio_module modules/mod_logio.so
+<IfModule !log_config_module>
+    LoadModule log_config_module modules/mod_log_config.so
+</IfModule>
+<IfModule !logio_module>
+    LoadModule logio_module modules/mod_logio.so
+</IfModule>
 LoadModule macro_module modules/mod_macro.so
 LoadModule mime_magic_module modules/mod_mime_magic.so
 LoadModule mime_module modules/mod_mime.so
@@ -59,9 +63,13 @@ LoadModule status_module modules/mod_status.so
 LoadModule substitute_module modules/mod_substitute.so
 LoadModule suexec_module modules/mod_suexec.so
 LoadModule unique_id_module modules/mod_unique_id.so
-LoadModule unixd_module modules/mod_unixd.so
+<IfModule !unixd_module>
+    LoadModule unixd_module modules/mod_unixd.so
+</IfModule>
 LoadModule userdir_module modules/mod_userdir.so
-LoadModule version_module modules/mod_version.so
+<IfModule !version_module>
+    LoadModule version_module modules/mod_version.so
+</IfModule>
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
 LoadModule proxy_module modules/mod_proxy.so

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -216,7 +216,15 @@ def setup_http(testdir, wrapenv):
     os.mkdir(os.path.join(httpdir, 'conf.d'))
     os.mkdir(os.path.join(httpdir, 'html'))
     os.mkdir(os.path.join(httpdir, 'logs'))
-    os.symlink('/etc/httpd/modules', os.path.join(httpdir, 'modules'))
+
+    distro = "Fedora"
+    moddir = "/etc/httpd/modules"
+    if not os.path.exists(moddir):
+        distro = "Debian"
+        moddir = "/usr/lib/apache2/modules"
+    if not os.path.exists(moddir):
+        raise ValueError("Could not find Apache module directory!")
+    os.symlink(moddir, os.path.join(httpdir, 'modules'))
 
     shutil.copy('src/.libs/mod_auth_gssapi.so', httpdir)
 
@@ -236,8 +244,9 @@ def setup_http(testdir, wrapenv):
                'MALLOC_PERTURB_': str(random.randint(0, 32767) % 255 + 1)}
     httpenv.update(wrapenv)
 
-    httpproc = subprocess.Popen(['httpd', '-DFOREGROUND', '-f', config],
-                                 env=httpenv, preexec_fn=os.setsid)
+    httpd = "httpd" if distro == "Fedora" else "apache2"
+    httpproc = subprocess.Popen([httpd, '-DFOREGROUND', '-f', config],
+                                env=httpenv, preexec_fn=os.setsid)
 
     return httpproc
 


### PR DESCRIPTION
This is mostly gunk around how the webserver is called and what is
built-in versus a module.  I have mostly added templating logic for
commenting pieces of the conf file.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

Right now, *master* is not passing the test suite on all systems (see #117), so this should perhaps wait to merge.

@tjaalton, this may be relevant to your interests.