### PR TITLE
rewrite: implicitly handle internal redirects

### DIFF
--- a/src/environ.h
+++ b/src/environ.h
@@ -8,6 +8,8 @@ void mag_get_name_attributes(request_rec *req,
                              gss_name_t name,
                              struct mag_conn *mc);
 
+void mag_export_req_env(request_rec *req, apr_table_t *env);
+
 void mag_set_req_data(request_rec *req,
                       struct mag_config *cfg,
                       struct mag_conn *mc);

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -52,6 +52,8 @@
 #  endif
 #endif
 
+extern module AP_MODULE_DECLARE_DATA auth_gssapi_module;
+
 struct mag_na_map {
     char *env_name;
     char *attr_name;
@@ -77,7 +79,7 @@ struct mag_config {
     uid_t deleg_ccache_uid;
     gid_t deleg_ccache_gid;
     gss_key_value_set_desc *cred_store;
-    bool deleg_ccache_unique;;
+    bool deleg_ccache_unique;
     bool s4u2self;
 #endif
     struct seal_key *mag_skey;
@@ -124,6 +126,7 @@ struct mag_conn {
     int na_count;
     struct mag_attr *name_attributes;
     const char *ccname;
+    apr_table_t *env;
 };
 
 #define discard_const(ptr) ((void *)((uintptr_t)(ptr)))

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -148,6 +148,23 @@ CoreDumpDirectory /tmp
   Require valid-user
 </Location>
 
+<Location /spnego_rewrite>
+  Options +Includes
+  AddOutputFilter INCLUDES .html
+
+  AuthType GSSAPI
+  AuthName "Login"
+  GssapiCredStore ccache:${HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore keytab:${HTTPROOT}/http.keytab
+  GssapiAllowedMech krb5
+  Require valid-user
+
+  RewriteEngine on
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteRule . /spnego_rewrite/index.html [L]
+</Location>
+
 <Location /spnego_negotiate_once>
   AuthType GSSAPI
   AuthName "Login Negotiate Once"

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -306,6 +306,24 @@ def test_spnego_auth(testdir, testenv, testlog):
             sys.stderr.write('SPNEGO No Auth: SUCCESS\n')
 
 
+def test_spnego_rewrite(testdir, testenv, testlog):
+
+    spnego_rewrite_dir = os.path.join(testdir, 'httpd', 'html',
+                                          'spnego_rewrite')
+    os.mkdir(spnego_rewrite_dir)
+    shutil.copy('tests/index.html', spnego_rewrite_dir)
+
+    with (open(testlog, 'a')) as logfile:
+        spnego = subprocess.Popen(["tests/t_spnego_rewrite.py"],
+                                  stdout=logfile, stderr=logfile,
+                                  env=testenv, preexec_fn=os.setsid)
+        spnego.wait()
+        if spnego.returncode != 0:
+            sys.stderr.write('SPNEGO Rewrite: FAILED\n')
+        else:
+            sys.stderr.write('SPNEGO Rewrite: SUCCESS\n')
+
+
 def test_spnego_negotiate_once(testdir, testenv, testlog):
 
     spnego_negotiate_once_dir = os.path.join(testdir, 'httpd', 'html',
@@ -399,6 +417,9 @@ if __name__ == '__main__':
         testenv['DELEGCCACHE'] = os.path.join(testdir, 'httpd',
                                               USR_NAME + '@' + TESTREALM)
         test_spnego_auth(testdir, testenv, testlog)
+
+        testenv['MAG_GSS_NAME'] = USR_NAME + '@' + TESTREALM
+        test_spnego_rewrite(testdir, testenv, testlog)
 
         test_spnego_negotiate_once(testdir, testenv, testlog)
 

--- a/tests/t_spnego_rewrite.py
+++ b/tests/t_spnego_rewrite.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+import requests
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+
+if __name__ == '__main__':
+    sess = requests.Session()
+    url = 'http://%s/spnego_rewrite/xxx' % os.environ['NSS_WRAPPER_HOSTNAME']
+    r = sess.get(url, auth=HTTPKerberosAuth())
+
+    if r.status_code != 200:
+        raise ValueError('Spnego Rewrite failed')
+
+    if r.text.rstrip() != os.environ['MAG_GSS_NAME']:
+        raise ValueError('Spnego Rewrite, GSS_NAME check failed')


### PR DESCRIPTION
Internal redirects are a special case of subrequest - they
have no req->main but req->prev instead, so we should check
for that too in case the request is not initial.

Also, make sure to export MAG environment variables to
subrequests and internal redirects.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>
Reported-by: scopev24

Fixes #114