### PR TITLE
Run the test suite using `make check`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,5 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = src/asn1c src
 
-test: all
+check: all
 	$(srcdir)/tests/magtests.py
+
+test: check


### PR DESCRIPTION
`make test` continues to be provided for compatibility.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

This was the second commit in #118 which seems to have gotten lost.