### PR TITLE
Add option to set alternative ccname env var

### DIFF
--- a/README
+++ b/README
@@ -176,8 +176,8 @@ options like keytab location, client_keytab location, ccache location etc.
 If delegation of credentials is desired credentials can be exported in a
 private directory accessible by the Apache process.
 The delegated credentials will be stored in a file named after the client
-principal and the subprocess environment variable KRB5CCNAME will be set
-to point to that file.
+principal and a request environment variable (`KRB5CCNAME` by default) will be
+set to point to that file.
 
 #### Example
     GssapiDelegCcacheDir /var/run/httpd/clientcaches
@@ -198,6 +198,16 @@ in the contrib directory.
 
 #### Example
     GssapiDelegCcacheUnique On
+
+
+### GssapiDelegCcacheEnvVar
+
+Set the name of the request environment variable that will receive the
+credential cache name.  If unspecified, defaults to `KRB5CCNAME`.
+
+#### Example
+    GssapiDelegCcacheEnvVar AJP_KRB5CCNAME
+
 
 ### GssapiUseS4U2Proxy
 

--- a/src/environ.c
+++ b/src/environ.c
@@ -243,8 +243,8 @@ static void mag_set_name_attributes(request_rec *req, struct mag_conn *mc)
     }
 }
 
-static void mag_set_KRB5CCNAME(request_rec *req, struct mag_config *cfg,
-                               struct mag_conn *mc)
+static void mag_set_ccname_envvar(
+        request_rec *req, struct mag_config *cfg, struct mag_conn *mc)
 {
     apr_status_t status;
     apr_int32_t wanted = APR_FINFO_MIN | APR_FINFO_OWNER | APR_FINFO_PROT;
@@ -287,7 +287,7 @@ static void mag_set_KRB5CCNAME(request_rec *req, struct mag_config *cfg,
     }
 
     value = apr_psprintf(req->pool, "FILE:%s", path);
-    apr_table_set(mc->env, "KRB5CCNAME", value);
+    apr_table_set(mc->env, cfg->ccname_envvar, value);
 }
 
 void mag_export_req_env(request_rec *req, apr_table_t *env)
@@ -316,7 +316,7 @@ void mag_set_req_data(request_rec *req,
 
 #ifdef HAVE_CRED_STORE
     if (cfg->deleg_ccache_dir && mc->delegated && mc->ccname) {
-        mag_set_KRB5CCNAME(req, cfg, mc);
+        mag_set_ccname_envvar(req, cfg, mc);
     }
 #endif
 

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1209,6 +1209,7 @@ static void *mag_create_dir_config(apr_pool_t *p, char *dir)
 
     cfg = (struct mag_config *)apr_pcalloc(p, sizeof(struct mag_config));
     cfg->pool = p;
+    cfg->ccname_envvar = "KRB5CCNAME";
 
     return cfg;
 }
@@ -1724,6 +1725,9 @@ static const command_rec mag_commands[] = {
                      OR_AUTHCFG, "Directory to store delegated credentials"),
     AP_INIT_ITERATE("GssapiDelegCcachePerms", mag_deleg_ccache_perms, NULL,
                      OR_AUTHCFG, "Permissions to assign to Ccache files"),
+    AP_INIT_TAKE1("GssapiDelegCcacheEnvVar", ap_set_string_slot,
+                    (void *)APR_OFFSETOF(struct mag_config, ccname_envvar),
+                    OR_AUTHCFG, "Environment variable to receive ccache name"),
     AP_INIT_FLAG("GssapiDelegCcacheUnique", mag_deleg_ccache_unique, NULL,
                  OR_AUTHCFG, "Use unique ccaches for delgation"),
     AP_INIT_FLAG("GssapiImpersonate", ap_set_flag_slot,

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -81,6 +81,7 @@ struct mag_config {
     gss_key_value_set_desc *cred_store;
     bool deleg_ccache_unique;
     bool s4u2self;
+    char *ccname_envvar;
 #endif
     struct seal_key *mag_skey;
 


### PR DESCRIPTION
In some cases (e.g. if you want to convey the ccname over AJP) the
request environment variable name "KRB5CCNAME" is not appropriate.
Add the GssapiDelegCcacheEnvVar option that allows the env var name
to be changed.

Fixes: https://github.com/modauthgssapi/mod_auth_gssapi/issues/123