### PR TITLE
Add option to select acceptor name

### DIFF
--- a/README
+++ b/README
@@ -398,3 +398,23 @@ an additional message that provides more context.
 
 - **Enable with:** GssapiPublishErrors On
 - **Default:** GssapiPublishErrors Off
+
+
+### GssapiAcceptorName
+
+This option is used to force the server to accept only for a specific name.
+
+This allows, for example to select to use a specific credential when multiple
+keys are provided in a keytab.
+
+Note: By default no name is set and any name in a keytab or mechanism specific
+acceptor credential will be allowed.
+
+Note: Global gssapi options set in krb5.conf like 'ignore_acceptor_hostname'
+may affect the ability to restrict names.
+
+Note: The GSS_C_NT_HOSTBASED_SERVICE format is used for names (see example).
+
+#### Example
+    GssapiAcceptorName HTTP@www.example.com
+

--- a/src/environ.c
+++ b/src/environ.c
@@ -28,7 +28,7 @@ static bool mag_get_name_attr(request_rec *req,
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req,
                       "gss_get_name_attribute() failed on %.*s%s",
                       (int)attr->name.length, (char *)attr->name.value,
-                      mag_error(req, "", maj, min));
+                      mag_error(req->pool, "", maj, min));
         return false;
     }
 
@@ -209,7 +209,7 @@ void mag_get_name_attributes(request_rec *req, struct mag_config *cfg,
 
     maj = gss_inquire_name(&min, name, NULL, NULL, &attrs);
     if (GSS_ERROR(maj)) {
-        error = mag_error(req, "gss_inquire_name() failed", maj, min);
+        error = mag_error(req->pool, "gss_inquire_name() failed", maj, min);
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, req, "%s", error);
         apr_table_set(mc->env, "GSS_NAME_ATTR_ERROR", error);
         return;

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -92,6 +92,7 @@ struct mag_config {
     bool negotiate_once;
     struct mag_name_attributes *name_attributes;
     bool enverrs;
+    gss_name_t acceptor_name;
 };
 
 struct mag_server_config {

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -136,4 +136,4 @@ struct mag_conn {
 
 struct mag_conn *mag_new_conn_ctx(apr_pool_t *pool);
 const char *mag_str_auth_type(int auth_type);
-char *mag_error(request_rec *req, const char *msg, uint32_t maj, uint32_t min);
+char *mag_error(apr_pool_t *pool, const char *msg, uint32_t maj, uint32_t min);

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -200,6 +200,17 @@ CoreDumpDirectory "${HTTPROOT}"
   Require valid-user
 </Location>
 
+<Location /bad_acceptor_name>
+  AuthType GSSAPI
+  AuthName "Bad Acceptor Name"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:${HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore client_keytab:${HTTPROOT}/http.keytab
+  GssapiCredStore keytab:${HTTPROOT}/http.keytab
+  GssapiAcceptorName BAD@example.com
+  Require valid-user
+</Location>
+
 <VirtualHost *:${PROXYPORT}>
   ProxyRequests On
   ProxyVia On

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -391,6 +391,23 @@ def test_basic_auth_krb5(testdir, testenv, testlog):
             sys.stderr.write('BASIC Proxy Auth: SUCCESS\n')
 
 
+def test_bad_acceptor_name(testdir, testenv, testlog):
+
+    bandir = os.path.join(testdir, 'httpd', 'html', 'bad_acceptor_name')
+    os.mkdir(bandir)
+    shutil.copy('tests/index.html', bandir)
+
+    with (open(testlog, 'a')) as logfile:
+        ban = subprocess.Popen(["tests/t_bad_acceptor_name.py"],
+                               stdout=logfile, stderr=logfile,
+                               env=testenv, preexec_fn=os.setsid)
+        ban.wait()
+        if ban.returncode != 0:
+            sys.stderr.write('BAD ACCEPTOR: SUCCESS\n')
+        else:
+            sys.stderr.write('BAD ACCEPTOR: FAILED\n')
+
+
 if __name__ == '__main__':
 
     args = parse_args()
@@ -424,6 +441,8 @@ if __name__ == '__main__':
         test_spnego_rewrite(testdir, testenv, testlog)
 
         test_spnego_negotiate_once(testdir, testenv, testlog)
+
+        test_bad_acceptor_name(testdir, testenv, testlog)
 
         testenv = {'MAG_USER_NAME': USR_NAME,
                    'MAG_USER_PASSWORD': USR_PWD,


### PR DESCRIPTION
This option is useful to select and allow only a specific credential
when keys for multiple principals are available in a keytab.
