### PR TITLE
Allow admins to selectively suppress negotiation

### DIFF
--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -211,6 +211,19 @@ CoreDumpDirectory "${HTTPROOT}"
   Require valid-user
 </Location>
 
+<Location /nonego>
+  BrowserMatch NONEGO gssapi-no-negotiate
+  AuthType GSSAPI
+  AuthName "Login"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:${HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore client_keytab:${HTTPROOT}/http.keytab
+  GssapiCredStore keytab:${HTTPROOT}/http.keytab
+  GssapiBasicAuth On
+  GssapiAllowedMech krb5
+  Require valid-user
+</Location>
+
 <VirtualHost *:${PROXYPORT}>
   ProxyRequests On
   ProxyVia On

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -410,6 +410,23 @@ def test_bad_acceptor_name(testdir, testenv, testlog):
             sys.stderr.write('BAD ACCEPTOR: FAILED\n')
 
 
+def test_no_negotiate(testdir, testenv, testlog):
+
+    nonego_dir = os.path.join(testdir, 'httpd', 'html', 'nonego')
+    os.mkdir(nonego_dir)
+    shutil.copy('tests/index.html', nonego_dir)
+
+    with (open(testlog, 'a')) as logfile:
+        spnego = subprocess.Popen(["tests/t_nonego.py"],
+                                  stdout=logfile, stderr=logfile,
+                                  env=testenv, preexec_fn=os.setsid)
+        spnego.wait()
+        if spnego.returncode != 0:
+            sys.stderr.write('NO Negotiate: FAILED\n')
+        else:
+            sys.stderr.write('NO Negotiate: SUCCESS\n')
+
+
 if __name__ == '__main__':
 
     args = parse_args()
@@ -453,6 +470,8 @@ if __name__ == '__main__':
                    'MAG_USER_PASSWORD_2': USR_PWD_2}
         testenv.update(kdcenv)
         test_basic_auth_krb5(testdir, testenv, testlog)
+
+        test_no_negotiate(testdir, testenv, testlog)
 
     finally:
         with (open(testlog, 'a')) as logfile:

--- a/tests/t_nonego.py
+++ b/tests/t_nonego.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+import requests
+
+
+if __name__ == '__main__':
+    url = 'http://%s/nonego/' % (os.environ['NSS_WRAPPER_HOSTNAME'])
+
+    # ensure a 401 with the appropriate WWW-Authenticate header is returned
+    # when no auth is provided
+    r = requests.get(url)
+    if r.status_code != 401:
+        raise ValueError('NO Negotiate failed - 401 expected')
+    if not (r.headers.get("WWW-Authenticate") and
+            r.headers.get("WWW-Authenticate").startswith("Negotiate")):
+        raise ValueError('NO Negotiate failed - WWW-Authenticate '
+                         'Negotiate header is absent')
+
+    # ensure a 401 with the WWW-Authenticate Negotiate header is absent
+    # when the special User-Agent is sent
+    r = requests.get(url, headers={'User-Agent': 'NONEGO'})
+    if r.status_code != 401:
+        raise ValueError('NO Negotiate failed - 401 expected')
+    if (r.headers.get("WWW-Authenticate") and
+        r.headers.get("WWW-Authenticate").startswith("Negotiate")):
+        raise ValueError('NO Negotiate failed - WWW-Authenticate '
+                         'Negotiate header is present, should be absent')


### PR DESCRIPTION
If the admin sets the gssapi-no-negotiate requets enironemnt variable,
then we suppress the ability to send Negotiate headers.
This is useful to slectively send negotiate only to specific whielisted
or blacklisted browsers, clients, IP Addresses, etc... based on
directives like BrowserMatch or SetEnvIf.

Signed-off-by: Simo Sorce <simo@redhat.com>
Resolves #135