### PR TITLE
Allow sourcing the acceptor_name from httpd

### DIFF
--- a/README
+++ b/README
@@ -407,6 +407,10 @@ This option is used to force the server to accept only for a specific name.
 This allows, for example to select to use a specific credential when multiple
 keys are provided in a keytab.
 
+A special value of {HOSTNAME} will make the code use the name apache sees in
+the httpd request to select the correct name to use. This may be useful to
+allow multiple names and multiple keys to be used on the same apache instance.
+
 Note: By default no name is set and any name in a keytab or mechanism specific
 acceptor credential will be allowed.
 

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -93,6 +93,7 @@ struct mag_config {
     struct mag_name_attributes *name_attributes;
     bool enverrs;
     gss_name_t acceptor_name;
+    bool acceptor_name_from_req;
 };
 
 struct mag_server_config {

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -224,6 +224,19 @@ CoreDumpDirectory "${HTTPROOT}"
   Require valid-user
 </Location>
 
+<Location /hostname_acceptor>
+  AuthType GSSAPI
+  AuthName "Login"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:${HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore client_keytab:${HTTPROOT}/http.keytab
+  GssapiCredStore keytab:${HTTPROOT}/http.keytab
+  GssapiBasicAuth Off
+  GssapiAllowedMech krb5
+  GssapiAcceptorName {HOSTNAME}
+  Require valid-user
+</Location>
+
 <VirtualHost *:${PROXYPORT}>
   ProxyRequests On
   ProxyVia On

--- a/tests/t_hostname_acceptor.py
+++ b/tests/t_hostname_acceptor.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+# Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+import requests
+import sys
+from stat import ST_MODE
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+
+if __name__ == '__main__':
+    sess = requests.Session()
+    url = 'http://%s/hostname_acceptor/' % sys.argv[1]
+    r = sess.get(url, auth=HTTPKerberosAuth(delegate=True))
+    if r.status_code != 200:
+        raise ValueError('Hostname-based acceptor failed')


### PR DESCRIPTION
The hostname the client uses to connect to apache is stored in the
request structure for modules to use.
This patch adds an option to specify that the acceptor name to be used
should be constructed on a per-request basis from this name.
This is simply achieved by specifying the literal string {HOSTNAME} to
the existing GssapiAcceptorName option insted of specifying a full
GSSAPI name.

Signed-off-by: Simo Sorce <simo@redhat.com>
Resolves #138