### PR TITLE
Add travis support

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+
+CFLAGS="-Werror"
+if [ x$COMPILER == xclang ]; then
+    CFLAGS+=" -Wno-missing-field-initializers"
+    CFLAGS+=" -Wno-missing-braces -Wno-cast-align"
+fi
+
+if [ -f /etc/debian_version ]; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get -y install $COMPILER \
+                   apache2-bin {apache2,libkrb5,libssl,gss-ntlmssp}-dev \
+                   python-{dev,requests,gssapi} lib{socket,nss}-wrapper \
+                   flex bison krb5-{kdc,admin-server} virtualenv pkg-config
+
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=880599 - too old
+    virtualenv --system-site-packages .venv
+    source .venv/bin/activate
+    pip install requests_kerberos
+elif [ -f /etc/fedora-release ]; then
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1483553 means that this will
+    # fail no matter what, but it will properly install the packages.
+    dnf -y install $COMPILER python-gssapi krb5-{server,workstation} \
+        {httpd,krb5,openssl,gssntlmssp}-devel {socket,nss}_wrapper \
+        python-requests{,-kerberos} autoconf automake libtool which bison \
+        flex mod_session redhat-rpm-config \
+        || true
+
+    if [ x$COMPILER == xclang ]; then
+        CFLAGS+=" -Wno-unused-command-line-argument"
+    fi
+else
+    echo "Distro not found!"
+    false
+fi
+
+autoreconf -fiv
+./configure CFLAGS="$CFLAGS" CC=$(which $COMPILER)
+make
+make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+# not required, but less confusing if defined
+language: C
+
+services:
+  - docker
+
+env:
+  - DISTRO=fedora:rawhide COMPILER=gcc
+  - DISTRO=fedora:rawhide COMPILER=clang
+  - DISTRO=debian:sid COMPILER=clang
+
+script:
+  - >
+    docker run
+    -v `pwd`:/tmp/build
+    -w /tmp/build
+    -e COMPILER=$COMPILER
+    $DISTRO /bin/bash -ex .travis.sh

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import argparse
@@ -395,7 +395,6 @@ def setup_keys(tesdir, env):
 
 
 def setup_http(testdir, so_dir, wrapenv):
-
     httpdir = os.path.join(testdir, 'httpd')
     if os.path.exists(httpdir):
         shutil.rmtree(httpdir)
@@ -705,6 +704,10 @@ if __name__ == '__main__':
 
         keysenv = setup_keys(testdir, kdcenv)
         testenv = kinit_user(testdir, kdcenv)
+
+        # support virtualenv
+        testenv['PATH'] = os.environ.get('PATH', '')
+        testenv['ViRTUAL_ENV'] = os.environ.get('VIRTUAL_ENV', '')
 
         testenv['DELEGCCACHE'] = os.path.join(testdir, 'httpd',
                                               USR_NAME + '@' + TESTREALM)

--- a/tests/t_bad_acceptor_name.py
+++ b/tests/t_bad_acceptor_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5.py
+++ b/tests/t_basic_k5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5_fail_second.py
+++ b/tests/t_basic_k5_fail_second.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5_two_users.py
+++ b/tests/t_basic_k5_two_users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_proxy.py
+++ b/tests/t_basic_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_hostname_acceptor.py
+++ b/tests/t_hostname_acceptor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2017 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_nonego.py
+++ b/tests/t_nonego.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_required_name_attr.py
+++ b/tests/t_required_name_attr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego.py
+++ b/tests/t_spnego.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_negotiate_once.py
+++ b/tests/t_spnego_negotiate_once.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_no_auth.py
+++ b/tests/t_spnego_no_auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_proxy.py
+++ b/tests/t_spnego_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_rewrite.py
+++ b/tests/t_spnego_rewrite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os


### PR DESCRIPTION
Currently we test Fedora (rawhide) and Debian (unstable).  Centos7 is not tested because we can't currently build there.  Both clang and gcc builds are run with -Werror.