### PR TITLE
Test suite cleanup

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -11,11 +11,12 @@ if [ -f /etc/debian_version ]; then
     DEBIAN_FRONTEND=noninteractive apt-get -y install $COMPILER pkg-config \
                    apache2-bin {apache2,libkrb5,libssl,gss-ntlmssp}-dev \
                    python-{dev,requests,gssapi} lib{socket,nss}-wrapper \
-                   flex bison krb5-{kdc,admin-server} python-requests-kerberos
+                   flex bison krb5-{kdc,admin-server,pkinit} \
+                   python-requests-kerberos
 elif [ -f /etc/fedora-release ]; then
     # https://bugzilla.redhat.com/show_bug.cgi?id=1483553 means that this will
     # fail no matter what, but it will properly install the packages.
-    dnf -y install $COMPILER python-gssapi krb5-{server,workstation} \
+    dnf -y install $COMPILER python-gssapi krb5-{server,workstation,pkinit} \
         {httpd,krb5,openssl,gssntlmssp}-devel {socket,nss}_wrapper \
         python-requests{,-kerberos} autoconf automake libtool which bison \
         flex mod_session redhat-rpm-config \

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -77,6 +77,7 @@ LoadModule proxy_http_module modules/mod_proxy_http.so
 
 LoadModule auth_gssapi_module mod_auth_gssapi.so
 
+Mutex file:${HTTPROOT}
 
 <Directory />
     Options +Includes

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -482,6 +482,7 @@ def test_spnego_auth(testdir, testenv, testlog):
     spnegodir = os.path.join(testdir, 'httpd', 'html', 'spnego')
     os.mkdir(spnegodir)
     shutil.copy('tests/index.html', spnegodir)
+    error_count = 0
 
     with (open(testlog, 'a')) as logfile:
         spnego = subprocess.Popen(["tests/t_spnego.py"],
@@ -490,6 +491,7 @@ def test_spnego_auth(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('SPNEGO: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('SPNEGO: SUCCESS\n')
 
@@ -500,6 +502,7 @@ def test_spnego_auth(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('SPNEGO Proxy Auth: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('SPNEGO Proxy Auth: SUCCESS\n')
 
@@ -510,9 +513,10 @@ def test_spnego_auth(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('SPNEGO No Auth: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('SPNEGO No Auth: SUCCESS\n')
-
+    return error_count
 
 def test_required_name_attr(testdir, testenv, testlog):
     for i in range(1, 5):
@@ -528,9 +532,10 @@ def test_required_name_attr(testdir, testenv, testlog):
         tattr.wait()
         if tattr.returncode != 0:
             sys.stderr.write('Required Name Attr: FAILED\n')
+            return 1
         else:
             sys.stderr.write('Required Name Attr: SUCCESS\n')
-
+            return 0
 
 def test_spnego_rewrite(testdir, testenv, testlog):
 
@@ -546,9 +551,10 @@ def test_spnego_rewrite(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('SPNEGO Rewrite: FAILED\n')
+            return 1
         else:
             sys.stderr.write('SPNEGO Rewrite: SUCCESS\n')
-
+            return 0
 
 def test_spnego_negotiate_once(testdir, testenv, testlog):
 
@@ -564,15 +570,17 @@ def test_spnego_negotiate_once(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('SPNEGO Negotiate Once: FAILED\n')
+            return 1
         else:
             sys.stderr.write('SPNEGO Negotiate Once: SUCCESS\n')
-
+            return 0
 
 def test_basic_auth_krb5(testdir, testenv, testlog):
 
     basicdir = os.path.join(testdir, 'httpd', 'html', 'basic_auth_krb5')
     os.mkdir(basicdir)
     shutil.copy('tests/index.html', basicdir)
+    error_count = 0
 
     with (open(testlog, 'a')) as logfile:
         basick5 = subprocess.Popen(["tests/t_basic_k5.py"],
@@ -581,6 +589,7 @@ def test_basic_auth_krb5(testdir, testenv, testlog):
         basick5.wait()
         if basick5.returncode != 0:
             sys.stderr.write('BASIC-AUTH: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('BASIC-AUTH: SUCCESS\n')
 
@@ -591,6 +600,7 @@ def test_basic_auth_krb5(testdir, testenv, testlog):
         basick5.wait()
         if basick5.returncode != 0:
             sys.stderr.write('BASIC-AUTH Two Users: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('BASIC-AUTH Two Users: SUCCESS\n')
 
@@ -601,6 +611,7 @@ def test_basic_auth_krb5(testdir, testenv, testlog):
         basick5.wait()
         if basick5.returncode != 0:
             sys.stderr.write('BASIC Fail Second User: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('BASIC Fail Second User: SUCCESS\n')
 
@@ -611,9 +622,11 @@ def test_basic_auth_krb5(testdir, testenv, testlog):
         basick5.wait()
         if basick5.returncode != 0:
             sys.stderr.write('BASIC Proxy Auth: FAILED\n')
+            error_count += 1
         else:
             sys.stderr.write('BASIC Proxy Auth: SUCCESS\n')
 
+    return error_count
 
 def test_bad_acceptor_name(testdir, testenv, testlog):
 
@@ -628,9 +641,10 @@ def test_bad_acceptor_name(testdir, testenv, testlog):
         ban.wait()
         if ban.returncode != 0:
             sys.stderr.write('BAD ACCEPTOR: SUCCESS\n')
+            return 0
         else:
             sys.stderr.write('BAD ACCEPTOR: FAILED\n')
-
+            return 1
 
 def test_no_negotiate(testdir, testenv, testlog):
 
@@ -645,9 +659,10 @@ def test_no_negotiate(testdir, testenv, testlog):
         spnego.wait()
         if spnego.returncode != 0:
             sys.stderr.write('NO Negotiate: FAILED\n')
+            return 1
         else:
             sys.stderr.write('NO Negotiate: SUCCESS\n')
-
+            return 0
 
 def test_hostname_acceptor(testdir, testenv, testlog):
 
@@ -675,9 +690,10 @@ def test_hostname_acceptor(testdir, testenv, testlog):
 
         if failed:
             sys.stderr.write('HOSTNAME ACCEPTOR: FAILED\n')
+            return 1
         else:
             sys.stderr.write('HOSTNAME ACCEPTOR: SUCCESS\n')
-
+            return 0
 
 if __name__ == '__main__':
 
@@ -692,7 +708,7 @@ if __name__ == '__main__':
     processes = dict()
 
     testlog = os.path.join(testdir, 'tests.log')
-
+    errs = 0
     try:
         wrapenv = setup_wrappers(testdir)
 
@@ -711,21 +727,21 @@ if __name__ == '__main__':
 
         testenv['DELEGCCACHE'] = os.path.join(testdir, 'httpd',
                                               USR_NAME + '@' + TESTREALM)
-        test_spnego_auth(testdir, testenv, testlog)
+        errs += test_spnego_auth(testdir, testenv, testlog)
 
         testenv['MAG_GSS_NAME'] = USR_NAME + '@' + TESTREALM
-        test_spnego_rewrite(testdir, testenv, testlog)
+        errs += test_spnego_rewrite(testdir, testenv, testlog)
 
-        test_spnego_negotiate_once(testdir, testenv, testlog)
+        errs += test_spnego_negotiate_once(testdir, testenv, testlog)
 
-        test_hostname_acceptor(testdir, testenv, testlog)
+        errs += test_hostname_acceptor(testdir, testenv, testlog)
 
-        test_bad_acceptor_name(testdir, testenv, testlog)
+        errs += test_bad_acceptor_name(testdir, testenv, testlog)
 
         if os.path.exists("/usr/lib64/krb5/plugins/preauth/pkinit.so") or \
            os.path.exists("/usr/lib/x86_64-linux-gnu/krb5/plugins/preauth/pkinit.so"):
             testenv = kinit_certuser(testdir, testenv)
-            test_required_name_attr(testdir, testenv, testlog)
+            errs += test_required_name_attr(testdir, testenv, testlog)
         else:
             sys.stderr.write("krb5 PKINIT module not found, skipping name "
                              "attribute tests\n")
@@ -735,12 +751,13 @@ if __name__ == '__main__':
                    'MAG_USER_NAME_2': USR_NAME_2,
                    'MAG_USER_PASSWORD_2': USR_PWD_2}
         testenv.update(kdcenv)
-        test_basic_auth_krb5(testdir, testenv, testlog)
+        errs += test_basic_auth_krb5(testdir, testenv, testlog)
 
-        test_no_negotiate(testdir, testenv, testlog)
+        errs += test_no_negotiate(testdir, testenv, testlog)
 
     finally:
         with (open(testlog, 'a')) as logfile:
             for name in processes:
                 logfile.write("Killing %s\n" % name)
                 os.killpg(processes[name].pid, signal.SIGTERM)
+        exit(errs)


### PR DESCRIPTION
- Ensure magtests.py reports failures
- Fix the issue with starting apache in containers
- Update the package lists to run the pkinit test
- Stop repeatedly re-opening the test log file during tests
- Various code cleanliness fixes