### PR TITLE
Update minimum Apache HTTPD version required

### DIFF
--- a/README
+++ b/README
@@ -17,8 +17,8 @@ extension](http://k5wiki.kerberos.org/wiki/Projects/Credential_Store_extensions)
 is necessary to achieve full functionality. Reduced functionality is
 provided without these extensions.
 
-    krb5 (>=1.11)
-    Apache (>=2.4)
+    MIT krb5 (>=1.11)
+    Apache httpd (>=2.4.11)
 
 ### Tests
 


### PR DESCRIPTION
We use some functions that were added only in v 2.4.11, make that the
minimum required version in the docs.

Resloves: #167
