### PR TITLE
Fix truncation on comparison in name attr maps

### DIFF
--- a/src/environ.c
+++ b/src/environ.c
@@ -340,9 +340,8 @@ void mag_get_name_attributes(request_rec *req, struct mag_config *cfg,
             /* Use the environment variable name matching the attribute name
              * from the map. */
             for (int j = 0; j < map_count; j++) {
-                if (strncmp(cfg->name_attributes->map[j].attr_name,
-                            attr.name.value,
-                            attr.name.length) == 0) {
+                if (mag_strbuf_equal(cfg->name_attributes->map[j].attr_name,
+                                     &attr.name)) {
                     attr.env_name = cfg->name_attributes->map[j].env_name;
                     break;
                 }

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -142,3 +142,4 @@ const char *mag_str_auth_type(int auth_type);
 char *mag_error(apr_pool_t *pool, const char *msg, uint32_t maj, uint32_t min);
 int mag_get_user_uid(const char *name, uid_t *uid);
 int mag_get_group_gid(const char *name, gid_t *gid);
+bool mag_strbuf_equal(const char *str, gss_buffer_t buf);

--- a/src/util.c
+++ b/src/util.c
@@ -64,3 +64,9 @@ int mag_get_group_gid(const char *name, gid_t *gid)
     free(buf);
     return ret;
 }
+
+bool mag_strbuf_equal(const char *str, gss_buffer_t buf)
+{
+    if (strncmp(str, buf->value, buf->length) != 0) return false;
+    return buf->length == strlen(str);
+}


### PR DESCRIPTION
The check to match a mapped name to a named attribute inadvertently
considered only the length of one of the strings.
This would cause incorrect prefix matches.

Fixes #173