### PR TITLE
Fix build with new flex/libfl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 env:
   - DISTRO=fedora:27 COMPILER=gcc
   - DISTRO=fedora:27 COMPILER=clang
-  - DISTRO=debian:testing COMPILER=clang
+  - DISTRO=debian:sid COMPILER=clang
 
 script:
   - >

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,8 +20,7 @@ mod_auth_gssapi_la_LDFLAGS = \
     $(MAG_LIBS) \
     -avoid-version \
     -module \
-    -export-symbols-regex auth_gssapi_module \
-    $(LEXLIB)
+    -export-symbols-regex auth_gssapi_module
 
 install-exec-local:
 	test -d $(DESTDIR)$(APXS_LIBEXECDIR) || mkdir -p $(DESTDIR)$(APXS_LIBEXECDIR)


### PR DESCRIPTION
Remove $(LEXLIB) from Makefile

libfl expects a symbol from elsewhere.  As a result, we end up linking
too much.  And since we're making a plugin, this error isn't
recognized until load time.

(The Travis commit doesn't have to merge; it's just to show that it's working again.)