### PR TITLE
Allow building without ap_log_rdata()

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -19,10 +19,14 @@ if [ -f /etc/debian_version ]; then
     virtualenv --system-site-packages .venv
     source .venv/bin/activate
     pip install requests-gssapi
-elif [ -f /etc/fedora-release ]; then
-    dnf -y install $COMPILER python-gssapi krb5-{server,workstation,pkinit} \
+elif [ -f /etc/redhat-release ]; then
+    DY=yum
+    if [ -f /etc/fedora-release ]; then
+        DY=dnf
+    fi
+    $DY -y install $COMPILER python-gssapi krb5-{server,workstation,pkinit} \
         {httpd,krb5,openssl,gssntlmssp}-devel {socket,nss}_wrapper \
-        python-requests autoconf automake libtool which bison \
+        python-requests autoconf automake libtool which bison make \
         flex mod_session redhat-rpm-config python2-virtualenv
 
     # remove when we're using f28+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DISTRO=fedora:27 COMPILER=gcc
   - DISTRO=fedora:27 COMPILER=clang
   - DISTRO=debian:sid COMPILER=clang
+  - DISTRO=centos:7 COMPILER=gcc
 
 script:
   - >

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,17 @@ AC_TYPE_UINT32_T
 # Checks for library functions.
 AC_CHECK_FUNCS([strcasecmp])
 
+AC_PATH_PROGS(APACHE, [apache2 httpd apache])
+if test x"$APACHE" == x; then
+	AC_MSG_ERROR([Can't find the apache2/httpd executable!])
+fi
+chk="$(objdump -d "$APACHE" | grep ap_log_rdata)"
+if test x"$chk" != x; then
+	AC_DEFINE([HAVE_AP_LOG_RDATA], [1], [ap_log_rdata() is present])
+else
+	AC_MSG_WARN([Apache/httpd is missing ap_log_rdata; some logging will be disabled])
+fi
+
 AC_ARG_WITH([installpath],
             [AS_HELP_STRING([--with-installpath=PATH],
                             [alternative install path])],

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -53,6 +53,10 @@
 extern module AP_MODULE_DECLARE_DATA auth_gssapi_module;
 #define GSS_NAME_ATTR_USERDATA "GSS Name Attributes Userdata"
 
+#ifndef HAVE_AP_LOG_RDATA
+#define ap_log_rdata(...)
+#endif
+
 struct mag_na_map {
     char *env_name;
     char *attr_name;


### PR DESCRIPTION
Apache added ap_log_rdata() in 2.4.11.  However, el7 only has apache
2.4.6, and it's not worth bumping our version requirement for just a
logging function.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>
Fixes: #184