### PR TITLE
Detect libcrypto function instead of using version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,10 +87,16 @@ AS_IF([test "x${APR}" != "x" -a -x "${APR}"],
        AC_SUBST(APR_LDFLAGS)],
       [AC_MSG_FAILURE(["apr-1-config not found. Use --with-apr"])])
 
+# OpenSSL availability and presence of specific functions
 PKG_CHECK_MODULES([OPENSSL], [openssl])
 AC_SUBST([OPENSSL_CFLAGS])
 AC_SUBST([OPENSSL_LIBS])
+save_LIBS=$LIBS
+LIBS="$LIBS $OPENSSL_LIBS"
+AC_CHECK_FUNCS(EVP_CIPHER_CTX_new HMAC_CTX_new)
+LIBS=$save_LIBS
 
+# GSSAPI availability and presence of specific functions
 AC_CHECK_HEADERS([gssapi/gssapi.h gssapi/gssapi_ext.h gssapi/gssapi_krb5.h],
                  ,[AC_MSG_ERROR([Could not find GSSAPI headers])])
 AC_CHECK_HEADERS([gssapi/gssapi_ntlmssp.h])

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,12 +1,13 @@
 /* Copyright (C) 2014 mod_auth_gssapi contributors - See COPYING for (C) terms */
 
+#include "config.h"
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <stdbool.h>
 #include "crypto.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#ifndef HAVE_HMAC_CTX_NEW
 HMAC_CTX *HMAC_CTX_new(void)
 {
     HMAC_CTX *ctx;
@@ -26,7 +27,9 @@ void HMAC_CTX_free(HMAC_CTX *ctx)
     HMAC_CTX_cleanup(ctx);
     OPENSSL_free(ctx);
 }
+#endif
 
+#ifndef HAVE_EVP_CIPHER_CTX_NEW
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void)
 {
     EVP_CIPHER_CTX *ctx;


### PR DESCRIPTION
Instead of trying to guess which version introduced new openssl
unctions we depend on, detect them in configure and declare them
only if they are not found.

This will fix #188 in a better way than playing with version numbers, hopefully