### PR TITLE
Allow gss_localname to work with at least mech_eap

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1271,7 +1271,11 @@ static int mag_complete(struct mag_req_cfg *req_cfg, struct mag_conn *mc,
 #endif
 
     if (cfg->map_to_local) {
-        maj = gss_localname(&min, client, mech_type, &lname);
+        /* We pass GSS_C_NO_OID here as passing mech_type does not work
+         * as expected with SPNEGO-wrapped names.
+         * http://krbdev.mit.edu/rt/Ticket/Display.html?id=8782
+         */
+        maj = gss_localname(&min, client, GSS_C_NO_OID, &lname);
         if (maj != GSS_S_COMPLETE) {
             mag_post_error(req, cfg, MAG_GSS_ERR, maj, min,
                            "gss_localname() failed");


### PR DESCRIPTION
For some reason, passing the mechanism as a parameter to gss_localname does not work with, at least, mech_eap (aka Moonshot).
```
GSS ERROR gss_localname() failed: [The operation or option is not available or unsupported (Name has no attributes)],
```
However, the name does have attributes. 

The gss-server.c example application (https://github.com/krb5/krb5/blob/master/src/appl/gss-sample/gss-server.c#L907) uses GSS_C_NO_OID, and using that value it works.

I've seen MIT KRB's mechglue seems to use the mechanism associated to the name if GSS_C_NO_OID. I wonder whether mechglue is associating mech_eap attributes to a wrong mechanism.