### PR TITLE
Fix integer sizes used with ap_set_flag_slot()

### DIFF
--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -83,7 +83,7 @@ struct mag_config {
     gid_t deleg_ccache_gid;
     gss_key_value_set_desc *cred_store;
     bool deleg_ccache_unique;
-    bool s4u2self;
+    int s4u2self;
     char *ccname_envvar;
 #endif
     struct seal_key *mag_skey;
@@ -94,7 +94,7 @@ struct mag_config {
     bool negotiate_once;
     struct mag_name_attributes *name_attributes;
     const char *required_na_expr;
-    bool enverrs;
+    int enverrs;
     gss_name_t acceptor_name;
     bool acceptor_name_from_req;
 };


### PR DESCRIPTION
ap_set_flag_slot() requires a field of type `int`.  Previously we
passed type `bool` in two places, causing test failures on s390x
because logging was not correctly configured.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>