### PR TITLE
Properly handle mech_type for basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ missing
 config.h
 config.h.in*
 stamp-h1
+cscope.out
+ylwrap
+src/lex.c
+src/parser.c
+src/parser.h
 *.o
 *.lo
 *.la

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1157,11 +1157,11 @@ static int mag_auth(request_rec *req)
 
     ret = mag_complete(req_cfg, mc, client, mech_type, vtime, delegated_cred);
 
+done:
     if (ret == OK && req_cfg->send_persist)
         apr_table_set(req->err_headers_out, "Persistent-Auth",
             cfg->gss_conn_ctx ? "true" : "false");
 
-done:
     if ((auth_type != AUTH_TYPE_BASIC) && (output.length != 0)) {
         int prefixlen = strlen(mag_str_auth_type(auth_type)) + 1;
         replen = apr_base64_encode_len(output.length) + 1;


### PR DESCRIPTION
Currently on Basic Auth mag_complete was basically always being called with an empty mech_type.
This will allow in future to consistently query via mech_type for both Negotiate and Basic Auth paths.
